### PR TITLE
Allow HashiCorp Vault Client as a root source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,9 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
   - 2.3
+  - 2.7
 
-before_install: gem install bundler
-
-matrix:
-  include:
-    - rvm: 1.8.7
-      gemfile: gemfiles/ruby-1.8.7.gemfile
-    - rvm: 1.9
-      gemfile: gemfiles/ruby-1.9.gemfile
+before_install:
+  - gem install bundler || gem install bundler --version '< 2'

--- a/figgy.gemspec
+++ b/figgy.gemspec
@@ -18,8 +18,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "json"
+  s.add_dependency 'vault', '~> 0.1'
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", '~> 3.0'
   s.add_development_dependency "simplecov", '~> 0.9'
   s.add_development_dependency "heredoc_unindent"
+  s.add_development_dependency "pry"
 end

--- a/gemfiles/ruby-1.8.7.gemfile
+++ b/gemfiles/ruby-1.8.7.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-# Specify your gem's dependencies in figgy.gemspec
-gemspec :path => '..'
-
-gem 'rake', '< 11'
-gem 'json', '< 2'

--- a/gemfiles/ruby-1.9.gemfile
+++ b/gemfiles/ruby-1.9.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-# Specify your gem's dependencies in figgy.gemspec
-gemspec path: '..'
-
-gem 'json', '< 2'

--- a/lib/figgy.rb
+++ b/lib/figgy.rb
@@ -3,6 +3,8 @@ require "erb"
 require "json"
 
 require "figgy/version"
+require "figgy/root"
+require "figgy/overlay"
 require "figgy/configuration"
 require "figgy/hash"
 require "figgy/finder"

--- a/lib/figgy/overlay.rb
+++ b/lib/figgy/overlay.rb
@@ -1,0 +1,34 @@
+class Figgy
+  class Overlay
+    # Internal name of the overlay, like +:environment+
+    attr_accessor :name
+
+    # The namespace (path) to search in, like +:staging+
+    attr_reader :namespace
+
+    # Roots to start searching from.
+    attr_accessor :roots
+
+    def initialize(name, namespace, roots)
+      @name = name
+      @namespace = namespace
+      @roots = Array(roots)
+    end
+
+    # Load all values for the given config +name+ at this overlay level.
+    #
+    # @return [Array<Object>] all found configuration data for +name+, in root precedence order
+    def load(name)
+      @roots.reduce([]) do |result, root|
+        value = root.fetch(@namespace, name)
+        result += value if value
+        result
+      end
+    end
+
+    # @return [Array<String>] the names of all existing configuration keys at this overlay level
+    def all_keys
+      @roots.map { |r| r.config_values(@namespace) }.flatten.uniq
+    end
+  end
+end

--- a/lib/figgy/root.rb
+++ b/lib/figgy/root.rb
@@ -1,0 +1,62 @@
+class Figgy
+  class Root
+    @handlers = []
+
+    class << self
+      attr_accessor :handlers
+    end
+
+    def initialize(source, path)
+      @source = source
+      @path = path
+    end
+  end
+
+  class VaultRoot < Root
+    def initialize(source, path)
+      super
+    end
+
+    def fetch(overlay, config_key)
+      secret = @source.logical.read(File.join(@path, overlay.to_s, config_key))
+      secret ? [JSON.parse(secret.data.to_json)] : nil
+    end
+
+    def config_values(overlay)
+      @source.logical.list(File.join(@path, overlay.to_s)).reject { |v| v.end_with?('/') }
+    end
+  end
+
+  class FileRoot < Root
+    def initialize(source, path)
+      super
+    end
+
+    def fetch(overlay, config_key)
+      files_for(File.join(overlay.to_s, config_key)).map do |f|
+        handler_for(f).call(File.read(f))
+      end
+    end
+
+    def config_values(overlay)
+      files_for(File.join(overlay.to_s, '*')).map do |f|
+        File.basename(f).sub(/\..+$/, '')
+      end
+    end
+
+    private
+
+    def handler_for(path)
+      match = Root.handlers.find { |ext, handler| path =~ /\.#{ext}$/ }
+      match && match.last
+    end
+
+    def files_for(name)
+      extensions = Root.handlers.map(&:first)
+      globs = extensions.map { |ext| "#{name}.#{ext}" }
+      filepaths = globs.map { |glob| File.join(@path, glob) }.flatten.uniq
+
+      Dir[*filepaths]
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'rspec'
 require 'figgy'
 require 'heredoc_unindent'
 
+require 'vault'
+
 module Figgy::SpecHelpers
   def current_dir
     File.join(Dir.getwd, 'tmp')


### PR DESCRIPTION
Allow configurations to be read from a [HashiCorp Vault](https://www.vaultproject.io/) client.

If a config would normally be stored under a file named foo.yml, in Vault it would be expected to be stored under the key foo.

The below would look for configurations in a Vault client at the path `secrets/live/here/staging`, and **override** configurations at the local file directory `./staging` (maintaining the Figgy feature of root directory precedence being in reverse order of definition).

```ruby
vault_client = Vault::Client.new(...)

AppConfig = Figgy.build do |config|
  config.set_root('secrets/live/here', vault_client)
  config.add_root('.')

  config.define_overlay(:default, nil)
  config.define_overlay(:environment, 'staging')
end
```

This PR also removes the `#define_combined_overlay` feature. Not sure that it was commonly used, and it wouldn't be compatible with Vault client roots.